### PR TITLE
Fix incorrect param name

### DIFF
--- a/vignettes/example-ratio-study.Rmd
+++ b/vignettes/example-ratio-study.Rmd
@@ -77,7 +77,7 @@ assessments <- read_json(
 sales <- read_json(
   paste0(
     "https://datacatalog.cookcountyil.gov/resource/wvhk-k5uv.json?",
-    "year=2020&$limit=100000"
+    "year=2020&$limit=10000"
   ),
   simplifyVector = TRUE
 ) %>%

--- a/vignettes/example-ratio-study.Rmd
+++ b/vignettes/example-ratio-study.Rmd
@@ -77,7 +77,7 @@ assessments <- read_json(
 sales <- read_json(
   paste0(
     "https://datacatalog.cookcountyil.gov/resource/wvhk-k5uv.json?",
-    "year=2020&$limit=10000"
+    "year=2020&$limit=100000"
   ),
   simplifyVector = TRUE
 ) %>%

--- a/vignettes/example-ratio-study.Rmd
+++ b/vignettes/example-ratio-study.Rmd
@@ -149,10 +149,10 @@ library(knitr)
 # values AND sales
 combined <- inner_join(
   assessments %>%
-    select(pin, year, township_name, mailed_tot, certified_tot, board_tot),
+    select(pin, tax_year, township_name, mailed_tot, certified_tot, board_tot),
   sales %>%
-    select(pin, year, sale_price, is_multisale),
-  by = c("pin", "year")
+    select(pin, tax_year, sale_price, is_multisale),
+  by = c("pin", "tax_year")
 ) %>%
   filter(township_name %in% c("New Trier", "Palatine"))
 

--- a/vignettes/example-ratio-study.Rmd
+++ b/vignettes/example-ratio-study.Rmd
@@ -151,8 +151,8 @@ combined <- inner_join(
   assessments %>%
     select(pin, tax_year, township_name, mailed_tot, certified_tot, board_tot),
   sales %>%
-    select(pin, tax_year, sale_price, is_multisale),
-  by = c("pin", "tax_year")
+    select(pin, year, sale_price, is_multisale),
+  by = c("pin", "tax_year" = "year")
 ) %>%
   filter(township_name %in% c("New Trier", "Palatine"))
 

--- a/vignettes/example-ratio-study.Rmd
+++ b/vignettes/example-ratio-study.Rmd
@@ -23,7 +23,7 @@ In general, there are four important statistics produced in sales ratio studies,
 | **COD**                 | 5 - 15           | How often properties with the *same* sale price receive the same predicted market value. Lower CODs indicate more fairness between similarly priced properties.                            |
 | **PRD**                 | .98 - 1.03       | How often properties with *different* sale prices receive the proportionately different predicted market values. Lower PRDs indicate more fairness between low and high-priced properties. |
 | **PRB**                 | -.05 - .05       | PRB is a different approach to measuring fairness across homes with different sale prices.                                                                                                 |
-| **Median Ratio**        | .095 - 1.05      | The median ratio measures whether the most common ratios accurately reflect sale prices.                                                                                                    |
+| **Median Ratio**        | .95 - 1.05      | The median ratio measures whether the most common ratios accurately reflect sale prices.                                                                                                    |
 | MKI                     | .95 - 1.05        | Measures the difference in inequality between assessed valuations and sale prices.                                               |
 | Sales Chasing (E.4)     | $\le$ 5%         | Measures the degree to which the statistics above are *true* reflections of the quality of assessments.                          |
 

--- a/vignettes/example-ratio-study.Rmd
+++ b/vignettes/example-ratio-study.Rmd
@@ -68,7 +68,7 @@ library(stringr)
 assessments <- read_json(
   paste0(
     "https://datacatalog.cookcountyil.gov/resource/uzyt-m557.json?",
-    "$where=starts_with(class,'2')&year=2020&$limit=100000"
+    "$where=starts_with(class,'2')&tax_year=2020&$limit=100000"
   ),
   simplifyVector = TRUE
 )


### PR DESCRIPTION
I believe the problem here is that we were referencing a parameter that doesn't exist. It works with `tax_year`. `year` doesn't seem to exist in the json structure.

Closes #7 