### PR TITLE
Update deploy permissions & actions

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,7 +41,6 @@ jobs:
           path: 'docs'
 
   deploy:
-    if: contains(fromJSON('["main", "master"]'), github.ref_name) && github.event_name != 'pull_request'
     needs: build-pkgdown-site
     runs-on: ubuntu-latest
     environment:
@@ -53,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Encoding: UTF-8
 LazyData: true
 Imports:
     stats
-RoxygenNote: 7.2.4
+RoxygenNote: 7.3.2
 Suggests:
     covr,
     devtools,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Encoding: UTF-8
 LazyData: true
 Imports:
     stats
-RoxygenNote: 7.3.2
+RoxygenNote: 7.2.4
 Suggests:
     covr,
     devtools,


### PR DESCRIPTION
When merging in https://github.com/ccao-data/assessr/pull/14, the docs were not updating from a new branch. This updates the deploy permissions and updates to the latest version of deploy-pages.