### PR TITLE
Upgrade-to-testthat-3rd-edition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,8 +34,9 @@ Suggests:
     rmarkdown,
     rprojroot,
     scales,
-    testthat,
+    testthat (>= 3.0.0),
     tibble,
     tidyr
 Depends: 
     R (>= 3.5.0)
+Config/testthat/edition: 3

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -1,15 +1,11 @@
 # Load the ratios sample dataset for testing
 data("ratios_sample")
-
 # Extract the components of the dataframe as vectors
 ratio <- ratios_sample$ratio
 sale_price <- ratios_sample$sale_price
 assessed <- ratios_sample$assessed
 
-
-
 ##### TEST COD CI #####
-
 # Calculate PRB CI
 cod_ci_out_95 <- cod_ci(ratio, nboot = 1000)
 cod_ci_out_80 <- cod_ci(ratio, nboot = 1000, alpha = 0.2)
@@ -22,10 +18,10 @@ test_that("returns expected type", {
 
 test_that("output equal to expected", {
   expect_equal(cod_ci_out_95, c(16.49595, 18.84529),
-               tolerance = 0.04, ignore_attr = TRUE
+    tolerance = 0.04, ignore_attr = TRUE
   )
   expect_equal(cod_ci_out_80, c(16.83710, 18.79953),
-               tolerance = 0.04, ignore_attr = TRUE
+    tolerance = 0.04, ignore_attr = TRUE
   )
 })
 
@@ -52,9 +48,7 @@ test_that("incomplete data returns NAs unless removed", {
   )
 })
 
-
 ##### TEST PRD CI #####
-
 # Calculate PRB CI
 prd_ci_out_95 <- prd_ci(assessed, sale_price, nboot = 1000)
 prd_ci_out_80 <- prd_ci(assessed, sale_price, nboot = 1000, alpha = 0.2)
@@ -67,10 +61,10 @@ test_that("returns expected type", {
 
 test_that("output equal to expected", {
   expect_equal(prd_ci_out_95, c(1.034447, 1.062625),
-               tolerance = 0.04, ignore_attr = TRUE
+    tolerance = 0.04, ignore_attr = TRUE
   )
   expect_equal(prd_ci_out_80, c(1.038444, 1.058439),
-               tolerance = 0.04, ignore_attr = TRUE
+    tolerance = 0.04, ignore_attr = TRUE
   )
 })
 
@@ -98,10 +92,7 @@ test_that("incomplete data returns NAs unless removed", {
   )
 })
 
-
-
 ##### TEST PRB CI #####
-
 # Calculate PRB CI
 prb_ci_out_95 <- prb_ci(assessed, sale_price)
 prb_ci_out_80 <- prb_ci(assessed, sale_price, alpha = 0.2)
@@ -114,10 +105,10 @@ test_that("returns expected type", {
 
 test_that("output equal to expected", {
   expect_equal(prb_ci_out_95, c(-0.01404379, 0.01899536),
-               tolerance = 0.04, ignore_attr = TRUE
+    tolerance = 0.04, ignore_attr = TRUE
   )
   expect_equal(prb_ci_out_80, c(-0.00831969, 0.01327127),
-               tolerance = 0.04, ignore_attr = TRUE
+    tolerance = 0.04, ignore_attr = TRUE
   )
 })
 
@@ -143,5 +134,4 @@ test_that("incomplete data returns NAs unless removed", {
     tolerance = 0.04,
     ignore_attr = TRUE
   )
-
 })

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -21,8 +21,10 @@ test_that("returns expected type", {
 })
 
 test_that("output equal to expected", {
-  expect_equivalent(cod_ci_out_95, c(16.49595, 18.84529), tolerance = 0.04)
-  expect_equivalent(cod_ci_out_80, c(16.83710, 18.79953), tolerance = 0.04)
+  expect_equal(cod_ci_out_95, c(16.49595, 18.84529),
+               tolerance = 0.04, ignore_attr = TRUE)
+  expect_equal(cod_ci_out_80, c(16.83710, 18.79953),
+               tolerance = 0.04, ignore_attr = TRUE)
 })
 
 test_that("bad input data stops execution", {
@@ -40,10 +42,11 @@ test_that("incomplete data returns NAs unless removed", {
     cod_ci(c(ratio, NA)),
     NA_real_
   )
-  expect_equivalent(
+  expect_equal(
     cod_ci(c(ratio, NA), nboot = 1000, na.rm = TRUE),
     c(16.49595, 18.84529),
-    tolerance = 0.04
+    tolerance = 0.04,
+    ignore_attr = TRUE
   )
 })
 
@@ -61,8 +64,10 @@ test_that("returns expected type", {
 })
 
 test_that("output equal to expected", {
-  expect_equivalent(prd_ci_out_95, c(1.034447, 1.062625), tolerance = 0.04)
-  expect_equivalent(prd_ci_out_80, c(1.038444, 1.058439), tolerance = 0.04)
+  expect_equal(prd_ci_out_95, c(1.034447, 1.062625),
+               tolerance = 0.04, ignore_attr = TRUE)
+  expect_equal(prd_ci_out_80, c(1.038444, 1.058439),
+               tolerance = 0.04, ignore_attr = TRUE)
 })
 
 test_that("bad input data stops execution", {
@@ -81,10 +86,11 @@ test_that("incomplete data returns NAs unless removed", {
     prd_ci(c(assessed, NA), c(sale_price, 10e5)),
     NA_real_
   )
-  expect_equivalent(
+  expect_equal(
     prd_ci(c(assessed, NA), c(sale_price, 10e5), na.rm = TRUE),
     c(1.034447, 1.062625),
-    tolerance = 0.04
+    tolerance = 0.04,
+    ignore_attr = TRUE
   )
 })
 
@@ -103,8 +109,10 @@ test_that("returns expected type", {
 })
 
 test_that("output equal to expected", {
-  expect_equivalent(prb_ci_out_95, c(-0.01404379, 0.01899536), tolerance = 0.04)
-  expect_equivalent(prb_ci_out_80, c(-0.00831969, 0.01327127), tolerance = 0.04)
+  expect_equal(prb_ci_out_95, c(-0.01404379, 0.01899536),
+               tolerance = 0.04, ignore_attr = TRUE)
+  expect_equal(prb_ci_out_80, c(-0.00831969, 0.01327127),
+               tolerance = 0.04, ignore_attr = TRUE)
 })
 
 test_that("bad input data stops execution", {
@@ -123,9 +131,11 @@ test_that("incomplete data returns NAs unless removed", {
     prb_ci(c(assessed, NA), c(sale_price, 10e5)),
     NA_real_
   )
-  expect_equivalent(
+  expect_equal(
     prb_ci(c(assessed, NA), c(sale_price, 10e5), na.rm = TRUE),
     c(-0.01404379, 0.01899536),
-    tolerance = 0.04
+    tolerance = 0.04,
+    ignore_attr = TRUE
   )
+
 })

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -5,7 +5,10 @@ ratio <- ratios_sample$ratio
 sale_price <- ratios_sample$sale_price
 assessed <- ratios_sample$assessed
 
+
+
 ##### TEST COD CI #####
+
 # Calculate PRB CI
 cod_ci_out_95 <- cod_ci(ratio, nboot = 1000)
 cod_ci_out_80 <- cod_ci(ratio, nboot = 1000, alpha = 0.2)
@@ -48,7 +51,10 @@ test_that("incomplete data returns NAs unless removed", {
   )
 })
 
+
+
 ##### TEST PRD CI #####
+
 # Calculate PRB CI
 prd_ci_out_95 <- prd_ci(assessed, sale_price, nboot = 1000)
 prd_ci_out_80 <- prd_ci(assessed, sale_price, nboot = 1000, alpha = 0.2)
@@ -92,7 +98,10 @@ test_that("incomplete data returns NAs unless removed", {
   )
 })
 
+
+
 ##### TEST PRB CI #####
+
 # Calculate PRB CI
 prb_ci_out_95 <- prb_ci(assessed, sale_price)
 prb_ci_out_80 <- prb_ci(assessed, sale_price, alpha = 0.2)

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -22,9 +22,11 @@ test_that("returns expected type", {
 
 test_that("output equal to expected", {
   expect_equal(cod_ci_out_95, c(16.49595, 18.84529),
-               tolerance = 0.04, ignore_attr = TRUE)
+               tolerance = 0.04, ignore_attr = TRUE
+  )
   expect_equal(cod_ci_out_80, c(16.83710, 18.79953),
-               tolerance = 0.04, ignore_attr = TRUE)
+               tolerance = 0.04, ignore_attr = TRUE
+  )
 })
 
 test_that("bad input data stops execution", {
@@ -65,9 +67,11 @@ test_that("returns expected type", {
 
 test_that("output equal to expected", {
   expect_equal(prd_ci_out_95, c(1.034447, 1.062625),
-               tolerance = 0.04, ignore_attr = TRUE)
+               tolerance = 0.04, ignore_attr = TRUE
+  )
   expect_equal(prd_ci_out_80, c(1.038444, 1.058439),
-               tolerance = 0.04, ignore_attr = TRUE)
+               tolerance = 0.04, ignore_attr = TRUE
+  )
 })
 
 test_that("bad input data stops execution", {
@@ -110,9 +114,11 @@ test_that("returns expected type", {
 
 test_that("output equal to expected", {
   expect_equal(prb_ci_out_95, c(-0.01404379, 0.01899536),
-               tolerance = 0.04, ignore_attr = TRUE)
+               tolerance = 0.04, ignore_attr = TRUE
+  )
   expect_equal(prb_ci_out_80, c(-0.00831969, 0.01327127),
-               tolerance = 0.04, ignore_attr = TRUE)
+               tolerance = 0.04, ignore_attr = TRUE
+  )
 })
 
 test_that("bad input data stops execution", {

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -1,5 +1,3 @@
-context("load testing data")
-
 # Load the ratios sample dataset for testing
 data("ratios_sample")
 
@@ -11,7 +9,6 @@ assessed <- ratios_sample$assessed
 
 
 ##### TEST COD CI #####
-context("test cod_ci function")
 
 # Calculate PRB CI
 cod_ci_out_95 <- cod_ci(ratio, nboot = 1000)
@@ -52,7 +49,6 @@ test_that("incomplete data returns NAs unless removed", {
 
 
 ##### TEST PRD CI #####
-context("test prb_ci function")
 
 # Calculate PRB CI
 prd_ci_out_95 <- prd_ci(assessed, sale_price, nboot = 1000)
@@ -95,7 +91,6 @@ test_that("incomplete data returns NAs unless removed", {
 
 
 ##### TEST PRB CI #####
-context("test prb_ci function")
 
 # Calculate PRB CI
 prb_ci_out_95 <- prb_ci(assessed, sale_price)

--- a/tests/testthat/test-formulas.R
+++ b/tests/testthat/test-formulas.R
@@ -1,5 +1,3 @@
-context("load testing data")
-
 # Load the ratios sample dataset for testing
 data("ratios_sample")
 
@@ -28,7 +26,6 @@ tiebreaks_Assessed_alt_sort_2 <- mki_tiebreaks$Assessed_alt_sort_2
 
 
 ##### TEST COD #####
-context("test cod function")
 
 # Calculate COD
 cod_out <- cod(ratio)
@@ -64,7 +61,6 @@ test_that("standard met function", {
 
 
 ##### TEST PRD #####
-context("test prd function")
 
 # Calculate PRD
 prd_out <- prd(assessed, sale_price)
@@ -108,7 +104,6 @@ test_that("standard met function", {
 
 
 ##### TEST PRB #####
-context("test prb function")
 
 # Calculate PRB
 prb_out <- prb(assessed, sale_price)
@@ -152,7 +147,6 @@ test_that("standard met function", {
 
 
 ##### TEST MKI #####
-context("test mki function")
 
 # Calculate MKI
 mki_out <- mki(mki_ki_assessed, mki_ki_sale_price)
@@ -212,7 +206,6 @@ test_that("all sorting variations return the same MKI (tiebreak data)", {
 
 
 ##### TEST KI #####
-context("test ki function")
 
 # Calculate KI
 ki_out <- ki(mki_ki_assessed, mki_ki_sale_price)
@@ -269,7 +262,6 @@ test_that("all sorting variations return return the same ki (tiebreak data)", {
 
 
 ##### TEST Median Ratio #####
-context("test median_ratio_met function")
 
 test_that("standard met function", {
   expect_true(med_ratio_met(median(ratio)))

--- a/tests/testthat/test-outliers.R
+++ b/tests/testthat/test-outliers.R
@@ -19,8 +19,6 @@ dist2_qnt_out <- is_outlier(test_dist2, method = "quantile")
 
 
 ##### TEST OUTLIER #####
-context("test is_outlier function")
-
 test_that("returns expected type", {
   expect_type(dist1_iqr_out, "logical")
   expect_vector(dist1_iqr_out)

--- a/tests/testthat/test-outliers.R
+++ b/tests/testthat/test-outliers.R
@@ -1,5 +1,3 @@
-context("load testing data")
-
 # Create test vectors of data with certain distributions
 set.seed(13378)
 

--- a/tests/testthat/test-sale_chasing.R
+++ b/tests/testthat/test-sale_chasing.R
@@ -1,5 +1,3 @@
-context("load testing data")
-
 # Load the ratios sample dataset for testing
 data("ratios_sample")
 

--- a/tests/testthat/test-sale_chasing.R
+++ b/tests/testthat/test-sale_chasing.R
@@ -9,8 +9,6 @@ chased_ratios <- c(rnorm(900, 1, 0.15), rep(1, 100))
 
 
 ##### TEST CHASING DETECTION #####
-context("test detect_chashing function")
-
 # Run detection
 sample_out <- detect_chasing(sample_ratios)
 normal_out <- detect_chasing(normal_ratios)


### PR DESCRIPTION
Upgrade to version 3 of testthat.
Followup to https://github.com/ccao-data/ccao/pull/51 and 
https://github.com/ccao-data/lightsnip/pull/22